### PR TITLE
chore: Allow renovate automerge for minor, patch and digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":rebaseStalePrs"
+  ],
+  "packageRules": [
+    {
+      "description": "Automatically merge minor and patch-level updates",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": [
+        "after 10pm every weekday",
+        "before 5am every weekday",
+        "every weekend"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
According to this [renovate best practices](https://www.augmentedmind.de/2023/07/30/renovate-bot-cheat-sheet/), the renovate configuration was modified ...
* to auto-merge minor, patch and digest
* without creating a PR
* only 10 p.m. to 5 a.m. on weekdays or on weekends
* after rebasing

"Note that Renovate won’t automatically merge PRs with failed CI pipeline runs" according to this [renovate best practices](https://www.augmentedmind.de/2023/07/30/renovate-bot-cheat-sheet/).

Fixes #47 