### PR TITLE
chore: Change renovate automerge type because of CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
       "description": "Automatically merge minor and patch-level updates",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
-      "automergeType": "branch",
+      "automergeType": "pr",
+      "automergeStrategy": "fast-forward",
       "schedule": [
         "after 10pm every weekday",
         "before 5am every weekday",


### PR DESCRIPTION
Change renovate automerge type because CI pipelines runs on PR